### PR TITLE
💚 Remove references to deleted migrations

### DIFF
--- a/omop/migrations/0001_initial.py
+++ b/omop/migrations/0001_initial.py
@@ -7,7 +7,9 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     initial = True
 
-    dependencies: list = []
+    dependencies: list = [
+        ("lamindb", "0081_revert_textfield_collection"),
+    ]
 
     operations = [
         migrations.CreateModel(

--- a/omop/migrations/0002_alter_caresite_options_alter_cdmsource_options_and_more.py
+++ b/omop/migrations/0002_alter_caresite_options_alter_cdmsource_options_and_more.py
@@ -10,10 +10,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        (
-            "lamindb",
-            "0069_alter_artifact__accessor_alter_artifact__hash_type_and_more",
-        ),
         ("omop", "0001_initial"),
     ]
 

--- a/omop/migrations/0003_remove_caresite__previous_runs_and_more.py
+++ b/omop/migrations/0003_remove_caresite__previous_runs_and_more.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("lamindb", "0081_revert_textfield_collection"),
         ("omop", "0002_alter_caresite_options_alter_cdmsource_options_and_more"),
     ]
 


### PR DESCRIPTION
To have migrations be compliant with the squashed migrations of lamindb v1.1.